### PR TITLE
Use the english.ini file as a fallback

### DIFF
--- a/scripts/lang/english.iss
+++ b/scripts/lang/english.iss
@@ -12,4 +12,7 @@ en.depinstall_status=Installing %1...
 en.depinstall_missing=%1 must be installed before setup can continue. Please install %1 and run Setup again.
 en.depinstall_error=An error occured while installing the dependencies. Please restart the computer and run the setup again or install the following dependencies manually:%n
 
-en.isxdl_langfile=
+en.isxdl_langfile=english.ini
+
+[Files]
+Source: "{#InnoDependencyInstallerDir}\scripts\isxdl\english.ini"; Flags: dontcopy noencryption


### PR DESCRIPTION
Fix a crash when installing with /LANG=es